### PR TITLE
Update Spline.cs

### DIFF
--- a/Assets/XJUnity3D/Geometry/Spline.cs
+++ b/Assets/XJUnity3D/Geometry/Spline.cs
@@ -23,7 +23,14 @@ namespace XJUnity3D.Geometry
         /// </returns>
         public Vector3 Position(float t)
         {
-            return CatmullSplineUtil.Position(t, GetControlPoint);
+            var i = Mathf.FloorToInt(t);
+            t -= i;
+
+            return CatmullSplineUtil.Position(t,
+                            GetControlPoint(i - 1).position,
+                            GetControlPoint(i).position,
+                            GetControlPoint(i + 1).position,
+                            GetControlPoint(i + 2).position);
         }
 
         /// <summary>
@@ -37,7 +44,14 @@ namespace XJUnity3D.Geometry
         /// </returns>
         public Vector3 Velosity(float t)
         {
-            return CatmullSplineUtil.Velocity(t, GetControlPoint);
+            var i = Mathf.FloorToInt(t);
+            t -= i;
+
+            return CatmullSplineUtil.Velocity(t,
+                            GetControlPoint(i - 1).position,
+                            GetControlPoint(i).position,
+                            GetControlPoint(i + 1).position,
+                            GetControlPoint(i + 2).position);
         }
 
         /// <summary>


### PR DESCRIPTION
fix gc alloc for Spline.Position / Velocity functions.

Spline.Positionの中で、CatmullSplineUtil.Position(float t, System.Func<int, ControlPoint> ctrlPointFunc)を呼んでいますが、引数のFuncでGC Allocが発生しているのでFuncを使わない方を呼ぶようにしてみましたが、どうでしょうか？
同様にVelocityも同じ修正をしてます。（Rotationもしたほうがいいかも）